### PR TITLE
Add omniauth-oauth2 as runtime dependency

### DIFF
--- a/omniauth-wix.gemspec
+++ b/omniauth-wix.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
+  spec.add_runtime_dependency 'omniauth-oauth2', '~> 1.5'
 end


### PR DESCRIPTION
On a brand new rails app, after running `bundle add omniauth-wix` and `bundle install`, starting my app throws an error:

```
/Users/wnm/.rvm/gems/ruby-3.1.1/gems/bootsnap-1.12.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:15:in `require': cannot load such file -- omniauth/strategies/oauth2 (LoadError)
	from /Users/wnm/.rvm/gems/ruby-3.1.1/gems/bootsnap-1.12.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:15:in `require'
	from /Users/wnm/.rvm/gems/ruby-3.1.1/gems/omniauth-wix-0.1.3/lib/omniauth/strategies/wix.rb:1:in `<main>'
	from /Users/wnm/.rvm/gems/ruby-3.1.1/gems/bootsnap-1.12.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
	from /Users/wnm/.rvm/gems/ruby-3.1.1/gems/bootsnap-1.12.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
	from /Users/wnm/.rvm/gems/ruby-3.1.1/gems/omniauth-wix-0.1.3/lib/omniauth/wix.rb:2:in `<main>'
	from /Users/wnm/.rvm/gems/ruby-3.1.1/gems/bootsnap-1.12.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
	from /Users/wnm/.rvm/gems/ruby-3.1.1/gems/bootsnap-1.12.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
	from /Users/wnm/.rvm/gems/ruby-3.1.1/gems/bundler-2.3.17/lib/bundler/runtime.rb:73:in `rescue in block in require'
	from /Users/wnm/.rvm/gems/ruby-3.1.1/gems/bundler-2.3.17/lib/bundler/runtime.rb:51:in `block in require'
	from /Users/wnm/.rvm/gems/ruby-3.1.1/gems/bundler-2.3.17/lib/bundler/runtime.rb:44:in `each'
	from /Users/wnm/.rvm/gems/ruby-3.1.1/gems/bundler-2.3.17/lib/bundler/runtime.rb:44:in `require'
	from /Users/wnm/.rvm/gems/ruby-3.1.1/gems/bundler-2.3.17/lib/bundler.rb:187:in `require'
	from /Users/wnm/projects/wix-report-app/exportly/config/application.rb:7:in `<main>'
	from /Users/wnm/.rvm/gems/ruby-3.1.1/gems/bootsnap-1.12.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
	from /Users/wnm/.rvm/gems/ruby-3.1.1/gems/bootsnap-1.12.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
	from /Users/wnm/.rvm/gems/ruby-3.1.1/gems/railties-7.0.3/lib/rails/command/actions.rb:22:in `require_application!'
	from /Users/wnm/.rvm/gems/ruby-3.1.1/gems/railties-7.0.3/lib/rails/command/actions.rb:14:in `require_application_and_environment!'
	from /Users/wnm/.rvm/gems/ruby-3.1.1/gems/railties-7.0.3/lib/rails/commands/console/console_command.rb:101:in `perform'
	from /Users/wnm/.rvm/gems/ruby-3.1.1/gems/thor-1.2.1/lib/thor/command.rb:27:in `run'
	from /Users/wnm/.rvm/gems/ruby-3.1.1/gems/thor-1.2.1/lib/thor/invocation.rb:127:in `invoke_command'
	from /Users/wnm/.rvm/gems/ruby-3.1.1/gems/thor-1.2.1/lib/thor.rb:392:in `dispatch'
	from /Users/wnm/.rvm/gems/ruby-3.1.1/gems/railties-7.0.3/lib/rails/command/base.rb:87:in `perform'
	from /Users/wnm/.rvm/gems/ruby-3.1.1/gems/railties-7.0.3/lib/rails/command.rb:48:in `invoke'
	from /Users/wnm/.rvm/gems/ruby-3.1.1/gems/railties-7.0.3/lib/rails/commands.rb:18:in `<main>'
	from /Users/wnm/.rvm/gems/ruby-3.1.1/gems/bootsnap-1.12.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
	from /Users/wnm/.rvm/gems/ruby-3.1.1/gems/bootsnap-1.12.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
	from bin/rails:4:in `<main>'
/Users/wnm/.rvm/gems/ruby-3.1.1/gems/bootsnap-1.12.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:15:in `require': cannot load such file -- omniauth-wix (LoadError)
	from /Users/wnm/.rvm/gems/ruby-3.1.1/gems/bootsnap-1.12.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:15:in `require'
	from /Users/wnm/.rvm/gems/ruby-3.1.1/gems/bundler-2.3.17/lib/bundler/runtime.rb:60:in `block (2 levels) in require'
	from /Users/wnm/.rvm/gems/ruby-3.1.1/gems/bundler-2.3.17/lib/bundler/runtime.rb:55:in `each'
	from /Users/wnm/.rvm/gems/ruby-3.1.1/gems/bundler-2.3.17/lib/bundler/runtime.rb:55:in `block in require'
	from /Users/wnm/.rvm/gems/ruby-3.1.1/gems/bundler-2.3.17/lib/bundler/runtime.rb:44:in `each'
	from /Users/wnm/.rvm/gems/ruby-3.1.1/gems/bundler-2.3.17/lib/bundler/runtime.rb:44:in `require'
	from /Users/wnm/.rvm/gems/ruby-3.1.1/gems/bundler-2.3.17/lib/bundler.rb:187:in `require'
	from /Users/wnm/projects/wix-report-app/exportly/config/application.rb:7:in `<main>'
	from /Users/wnm/.rvm/gems/ruby-3.1.1/gems/bootsnap-1.12.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
	from /Users/wnm/.rvm/gems/ruby-3.1.1/gems/bootsnap-1.12.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
	from /Users/wnm/.rvm/gems/ruby-3.1.1/gems/railties-7.0.3/lib/rails/command/actions.rb:22:in `require_application!'
	from /Users/wnm/.rvm/gems/ruby-3.1.1/gems/railties-7.0.3/lib/rails/command/actions.rb:14:in `require_application_and_environment!'
	from /Users/wnm/.rvm/gems/ruby-3.1.1/gems/railties-7.0.3/lib/rails/commands/console/console_command.rb:101:in `perform'
	from /Users/wnm/.rvm/gems/ruby-3.1.1/gems/thor-1.2.1/lib/thor/command.rb:27:in `run'
	from /Users/wnm/.rvm/gems/ruby-3.1.1/gems/thor-1.2.1/lib/thor/invocation.rb:127:in `invoke_command'
	from /Users/wnm/.rvm/gems/ruby-3.1.1/gems/thor-1.2.1/lib/thor.rb:392:in `dispatch'
	from /Users/wnm/.rvm/gems/ruby-3.1.1/gems/railties-7.0.3/lib/rails/command/base.rb:87:in `perform'
	from /Users/wnm/.rvm/gems/ruby-3.1.1/gems/railties-7.0.3/lib/rails/command.rb:48:in `invoke'
	from /Users/wnm/.rvm/gems/ruby-3.1.1/gems/railties-7.0.3/lib/rails/commands.rb:18:in `<main>'
	from /Users/wnm/.rvm/gems/ruby-3.1.1/gems/bootsnap-1.12.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
	from /Users/wnm/.rvm/gems/ruby-3.1.1/gems/bootsnap-1.12.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
```

As a fix, I added `omniauth-oauth2` to my Gemfile, but I think you should add it as a run time dependency?